### PR TITLE
feat: Implement parallel mining for improved performance

### DIFF
--- a/crates/nockchain/src/lib.rs
+++ b/crates/nockchain/src/lib.rs
@@ -31,6 +31,8 @@ use nockvm::noun::{D, T};
 use nockvm_macros::tas;
 use tracing::{debug, info, instrument};
 
+use num_cpus; // Added num_cpus import
+
 use crate::mining::MiningKeyConfig;
 
 /// Module for handling driver initialization signals
@@ -570,9 +572,10 @@ pub async fn init_with_kernel(
     });
 
     let mine = cli.as_ref().map_or(false, |c| c.mine);
+    let max_miners = Some(num_cpus::get().max(1)); // Use num_cpus
 
     let mining_driver =
-        crate::mining::create_mining_driver(mining_config, mine, Some(mining_init_tx));
+        crate::mining::create_mining_driver(mining_config, mine, max_miners, Some(mining_init_tx));
     nockapp.add_io_driver(mining_driver).await;
 
     let libp2p_driver = nockchain_libp2p_io::nc::make_libp2p_driver(


### PR DESCRIPTION
This change optimizes the nockchain mining algorithm by enabling concurrent mining attempts.

Key modifications include:
- Updated `create_mining_driver` in `crates/nockchain/src/mining.rs` to manage a configurable number of mining tasks in parallel using `tokio::task::JoinSet`.
- Introduced a new configuration parameter `max_concurrent_miners_config: Option<usize>` to `create_mining_driver`.
- The number of concurrent miners defaults to the number of CPU cores available on the system (`num_cpus::get().max(1)`), passed from `crates/nockchain/src/lib.rs`. If not specified or set to 0, it defaults to 1.
- Added logging to indicate when the concurrency limit is reached and candidates are queued.

The ZKVM (`nockapp::Kernel`) architecture, which spawns a dedicated OS thread per kernel instance, supports this parallel execution. These changes should lead to better CPU utilization and faster mining, especially on multi-core systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Mining operations now automatically utilize multiple CPU cores for improved performance, adjusting the number of concurrent mining tasks based on your system's available CPUs.

- **Bug Fixes**
	- Improved handling of mining task queueing to prevent loss of mining candidates when system is under heavy load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->