### PR TITLE
fix: Resolve build error and remove unused imports

### DIFF
--- a/crates/nockchain/Cargo.toml
+++ b/crates/nockchain/Cargo.toml
@@ -31,6 +31,7 @@ libp2p = { workspace = true, features = [
     "cbor",
 ] }
 nockchain-libp2p-io.workspace = true
+num_cpus = "1.16.0"
 tempfile = { workspace = true }
 termcolor.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/nockchain/src/lib.rs
+++ b/crates/nockchain/src/lib.rs
@@ -8,10 +8,9 @@ use clap::{arg, command, ArgAction, Parser};
 use libp2p::identity::Keypair;
 use libp2p::multiaddr::Multiaddr;
 use libp2p::{allow_block_list, connection_limits, memory_connection_limits, PeerId};
-use nockapp::driver::Operation;
 use nockapp::kernel::boot;
 use nockapp::wire::Wire;
-use nockapp::{one_punch_driver, NockApp, NounExt};
+use nockapp::NockApp;
 use nockchain_bitcoin_sync::{bitcoin_watcher_driver, BitcoinRPCConnection, GenesisNodeType};
 use nockchain_libp2p_io::p2p::{
     MAX_ESTABLISHED_CONNECTIONS, MAX_ESTABLISHED_CONNECTIONS_PER_PEER,


### PR DESCRIPTION
This commit addresses a build failure caused by a missing `num_cpus` dependency and cleans up unused import statements.

- Added `num_cpus = "1.16.0"` to `crates/nockchain/Cargo.toml`.
- Removed unused imports (`Operation`, `one_punch_driver`, `NounExt`) from `crates/nockchain/src/lib.rs`.

These changes ensure the project compiles successfully and reduce compiler warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to include an additional external library.
  - Cleaned up unused import statements to improve code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->